### PR TITLE
[Fix]turbolinksを無効化

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,10 +4,10 @@
 // that code so it'll be compiled.
 
 import Rails from '@rails/ujs';
-import Turbolinks from 'turbolinks';
+//import Turbolinks from 'turbolinks';
 import * as ActiveStorage from '@rails/activestorage';
 import 'router';
 
 Rails.start();
-Turbolinks.start();
+//Turbolinks.start();
 ActiveStorage.start();


### PR DESCRIPTION
## 概要
### turbolinksを無効化
デプロイ時の挙動の確認のため有効化していたが表示がくずれたので無効化した