### PR TITLE
fix: herokuにデプロイできない不具合が出た修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module VowelTraining
     config.generators.system_tests = nil
 
     config.i18n.default_locale = :ja
-    config.i18n.load_path += Dir[Rails.root.join(config / locales, '**', '*.{rb,yml}').to_s]
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
 


### PR DESCRIPTION
## 概要
### rubocopを通した後herokuにデプロイできない不具合が出たので修正しました
- application.rbのi18nのpathの記述が間違えていたので修正


close #60 