### PR TITLE
fix: 本番環境でmodeの文章が表示されていなかった不具合を修正 #96

### DIFF
--- a/app/javascript/pages/mode/index.vue
+++ b/app/javascript/pages/mode/index.vue
@@ -64,7 +64,7 @@ export default {
   },
   methods: {
     fetchModes() {
-      this.$axios.get('modes')
+      this.$axios.get('/modes')
 
 
         .then(res => this.modes = res.data)


### PR DESCRIPTION
## 概要
本番環境でmodeの文章が表示されていなかった不具合を修正

## やったこと
- herokuにseed_fuのデータを入れ直す
- modesのAPIのURLを修正