### PR TITLE
fix: adminLTEのcssがvueコンポーネントにも適用されてしまっていた部分を修正 #110

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= favicon_link_tag('favicon.ico') %>
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -86,7 +86,7 @@ production:
   compile: false
 
   # Extract and emit a css file
-  extract_css: true
+  extract_css: false
 
   # Cache manifest.json for performance
   cache_manifest: true


### PR DESCRIPTION
## 概要
adminLTEのcssがvueコンポーネントでも適用されてしまっていた部分を修正

## 詳細
- application.html.erbの記述を変更
- webpacker.ymlの記述を変更

## コメント
style_pack_tagを記述してcssをwebpackで管理するように変更した
これによりcssが当たらなくなったのを確認

webpackerの設定もdevelopmentとproductionでcssの読み込み方が違っていたので統一した。