### PR TITLE
fix: OGP画像がリンクになってない部分を修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,7 @@
 module ApplicationHelper
   def default_meta_tags
     {
+      site: 'BOIトレ',
       title: 'BOIトレ ~母音法で発声練習~',
       description: 'BOIトレは劇団四季も使っている母音法で練習する、発声練習・滑舌改善サービスです。',
       canonical: request.original_url,   #優先するurlを指定する
@@ -10,7 +11,7 @@ module ApplicationHelper
         title: :title,
         description: :description, 
         type: 'website',
-        site_name: 'BOIトレ',
+        site_name: :site,
         url: request.original_url,
         image: image_url('boitore_ogp.png'),
         locale: 'ja_JP',


### PR DESCRIPTION
## 概要
OGP画像がリンクになっていない部分を修正と思ったが
tweet前段階での確認だったためリンクになっていないだけだった
ツイートしたらリンクになっていた