### PR TITLE
feat: 練習の削除機能を実装, デザイン調整 #156

### DIFF
--- a/app/controllers/api/play_results_controller.rb
+++ b/app/controllers/api/play_results_controller.rb
@@ -16,6 +16,12 @@ class Api::PlayResultsController < ApplicationController
     end
   end
 
+  def destroy
+    play_results = PlayResult.find(params[:id])
+    play_results.destroy
+    render json: true 
+  end
+  
   private
 
   def play_results_params

--- a/app/javascript/components/calendar/TheCalendar.vue
+++ b/app/javascript/components/calendar/TheCalendar.vue
@@ -108,6 +108,15 @@
               >
                 {{ selectedEvent.start }}
               </div>
+              <v-spacer />
+              <v-btn
+                outlined
+                small
+                class="ma-4 white--text"
+                @click="DeleteResult"
+              >
+                削除する
+              </v-btn>
             </v-toolbar>
             <v-simple-table>
               <template v-slot:default>
@@ -200,6 +209,7 @@ export default {
       for (let i = 0; i < this.play_results.length; i++) {
         const first =  moment(this.play_results[i].created_at).format('yyyy-MM-DD-HH:mm');
         const name = this.play_results[i].practiced_sentence
+        const id = this.play_results[i].id
         const practiced_normal = this.play_results[i].practiced_normal
         const practiced_boin = this.play_results[i].practiced_boin
         const normal_voice = this.play_results[i].normal_voice
@@ -207,6 +217,7 @@ export default {
         const score = this.play_results[i].score
         const judge = this.play_results[i].judge
         events.push({
+          id: id,
           name: name,
           start: first,
           color: 'red lighten-1',
@@ -243,7 +254,7 @@ export default {
         this.getEvents();
       }
       catch(error) {
-        console.log(err.status)
+        console.log(error)
       }
     },
     showEvent ({ nativeEvent, event }) {
@@ -266,7 +277,29 @@ export default {
     viewDay ({ date }) {
       this.value = date
       this.type = 'day'
-    }
+    },
+    async DeleteResult(){
+      try{
+        let accept = confirm('本当に削除しますか？')
+        if(accept) {
+          const result = await this.$axios.delete('/api/play_results/' + this.selectedEvent.id , {
+            headers: {
+              uid: this.uid,
+              "access-token": this.token,
+              client: this.client,
+            },
+          })
+          console.log(result.data)
+          this.$router.go(this.$router.currentRoute.path)
+        }
+        else {
+          console.log(accept)
+        }
+      }
+      catch(error) {
+        console.log(error)
+      }
+    } 
   }
-};
+}
 </script>

--- a/app/javascript/components/calendar/TheResultTable.vue
+++ b/app/javascript/components/calendar/TheResultTable.vue
@@ -37,6 +37,15 @@
             >
               {{ formatDate(editedItem.created_at) }}
             </div>
+            <v-spacer />
+            <v-btn
+              outlined
+              small
+              class="ma-4 white--text"
+              @click="DeleteResult"
+            >
+              削除する
+            </v-btn>
           </v-toolbar>
           <v-simple-table>
             <template v-slot:default>
@@ -154,7 +163,29 @@ export default {
     },
     formatDate(value) {
       return moment(value).format("YYYY年MM月DD日")
-    }
+    },
+    async DeleteResult(){
+      try{
+        let accept = confirm('本当に削除しますか？')
+        if(accept) {
+          const result = await this.$axios.delete('/api/play_results/' + this.selectedEvent.id , {
+            headers: {
+              uid: this.uid,
+              "access-token": this.token,
+              client: this.client,
+            },
+          })
+          console.log(result.data)
+          this.$router.go(this.$router.currentRoute.path)
+        }
+        else {
+          console.log(accept)
+        }
+      }
+      catch(error) {
+        console.log(error)
+      }
+    } 
   },
 }
 </script>

--- a/app/javascript/components/result/ThePracticeResult.vue
+++ b/app/javascript/components/result/ThePracticeResult.vue
@@ -290,7 +290,7 @@ export default {
           this.$store.dispatch(
             "message/showMessage",
             {
-              message: "文章を保存しました。",
+              message: "練習内容を保存しました。",
               type: "success",
               status: true,
             },

--- a/app/javascript/components/shared/TheFlashMessage.vue
+++ b/app/javascript/components/shared/TheFlashMessage.vue
@@ -5,7 +5,7 @@
     right
     top
     :color="type"
-    timeout="9000"
+    timeout="6000"
   >
     <div class="ml-5 font-weight-bold white--text">
       {{ message }}

--- a/app/javascript/components/shared/TheHeader.vue
+++ b/app/javascript/components/shared/TheHeader.vue
@@ -102,7 +102,7 @@
             :to="{ name: 'Terms'}"
           >
             <v-list-item
-            class="mt-9"
+              class="mt-9"
             >
               <v-list-item-icon>
                 <v-icon>mdi-note-text-outline</v-icon>
@@ -111,7 +111,7 @@
             </v-list-item>
           </router-link>
 
-           <router-link
+          <router-link
             :to="{ name: 'PrivacyPolicy'}"
           >
             <v-list-item>
@@ -122,7 +122,7 @@
             </v-list-item>
           </router-link>
 
-           <router-link
+          <router-link
             :to="{ name: 'Contact'}"
           >
             <v-list-item>

--- a/app/javascript/pages/mode/index.vue
+++ b/app/javascript/pages/mode/index.vue
@@ -54,7 +54,7 @@ export default {
         this.modes = res.data
       }
       catch(error) {
-        console.log(err.status); 
+        console.log(error); 
       }
     }
   }

--- a/app/javascript/pages/top/index.vue
+++ b/app/javascript/pages/top/index.vue
@@ -23,7 +23,6 @@
           color="error"
           x-large
           dark
-          rounded
           @click.stop="isPlay"
         >
           練習してみる！

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     resources :modes, only: %i[index] do
       resources :selects, only: %i[index show]
     end
-    resources :play_results, only: %i[index create]
+    resources :play_results, only: %i[index create destroy]
   end
   get '*path', to: 'top#index'
 end


### PR DESCRIPTION
## 概要
Mypageにて練習結果の削除機能を実装した
デザインも少し調整

## 詳細
- ルーティングを追加
- playresults_controllerにdestroy アクションを追加
- vueコンポーネント側でapiを呼び出すメソッドを定義
- ボタンを設置
- デザインを調整