### PR TITLE
fix: 本番環境のseed_fuエラーを修正 #183

### DIFF
--- a/db/fixtures/production/mode.rb
+++ b/db/fixtures/production/mode.rb
@@ -17,3 +17,4 @@ Mode.seed do |s|
   s.id = 4
   s.difficulty = "おに"
   s.description="発音が鬼のように難しい言葉が練習できます。"
+end


### PR DESCRIPTION
## 概要
productionのseed_fuでmode.rbにendタグを入れ忘れていたので修正する。

## 詳細
- seed_fu productionフォルダのmode.rbを修正