### PR TITLE
refactor: 軽量化を図る

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script>
-import TheHeader from "components/shared/TheHeader"
+const  TheHeader  = () => import('components/shared/TheHeader');
 
 export default {
   components: {

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script>
-const  TheHeader  = () => import('components/shared/TheHeader');
+import TheHeader from 'components/shared/TheHeader'
 
 export default {
   components: {

--- a/app/javascript/components/how-to/TheAfterSignUp.vue
+++ b/app/javascript/components/how-to/TheAfterSignUp.vue
@@ -8,9 +8,9 @@
       練習保存機能
     </div>
     <v-img
-      src="https://res.cloudinary.com/dzlhvpfmo/image/upload/v1651839957/boi%E3%83%88%E3%83%AC/14caecababc47167a653af9bcea383dd_ddmqi0.webp"
+      src="https://res.cloudinary.com/dzlhvpfmo/image/upload/v1651839957/boi%E3%83%88%E3%83%AC/14caecababc47167a653af9bcea383dd_ddmqi0.png"
       max-width="100%"
-      max-height="90vh"
+      max-height="80vh"
     />
     <p
       class="pt-5"
@@ -30,7 +30,7 @@
     <v-img
       src="https://res.cloudinary.com/dzlhvpfmo/image/upload/v1651848206/boi%E3%83%88%E3%83%AC/82c12d5b788af2c08eccde25941dbbcb_fokzhx.jpg"
       width="100%"
-      height="90vh"
+      height="80vh"
     />
     <p
       class="pt-5"

--- a/app/javascript/components/how-to/TheAfterSignUp.vue
+++ b/app/javascript/components/how-to/TheAfterSignUp.vue
@@ -63,7 +63,7 @@
         <v-icon
           class="mr-2"
         >
-          mdi-file-sign
+          {{ icons.file }}
         </v-icon>
         新規登録!
       </v-btn>
@@ -76,7 +76,7 @@
         <v-icon
           class="mr-2"
         >
-          mdi-microphone
+          {{ icons.mic }}
         </v-icon>
         Start!
       </v-btn>
@@ -84,8 +84,19 @@
   </v-card>
 </template>
 <script>
+import { mdiMicrophone } from '@mdi/js'
+import { mdiFileSign } from '@mdi/js'
+
 export default{
-  name: 'TheAfterSignUp'
+  name: 'TheAfterSignUp',
+  data() {
+    return {
+      icons: {
+        mic: mdiMicrophone,
+        file: mdiFileSign
+      }
+    }
+  }
 
 }
 </script>

--- a/app/javascript/components/how-to/TheHowToPlay.vue
+++ b/app/javascript/components/how-to/TheHowToPlay.vue
@@ -130,7 +130,7 @@
         <v-icon
           class="mr-2"
         >
-          mdi-file-sign
+          {{ icons.file }}
         </v-icon>
         新規登録!
       </v-btn>
@@ -143,7 +143,7 @@
         <v-icon
           class="mr-2"
         >
-          mdi-microphone
+          {{ icons.mic }}
         </v-icon>
         Start!
       </v-btn>
@@ -151,9 +151,19 @@
   </v-card>
 </template>
 <script>
-export default{
-  name: 'TheHowToPlay'
+import { mdiMicrophone } from '@mdi/js'
+import { mdiFileSign } from '@mdi/js'
 
+export default{
+  name: 'TheHowToPlay',
+  data() {
+    return {
+      icons: {
+        mic: mdiMicrophone,
+        file: mdiFileSign
+      }
+    }
+  }
 }
 </script>
 <style scoped>

--- a/app/javascript/components/how-to/TheHowToPlay.vue
+++ b/app/javascript/components/how-to/TheHowToPlay.vue
@@ -8,7 +8,7 @@
       Step.1 モードを選択する
     </div>
     <v-img
-      src="https://res.cloudinary.com/dzlhvpfmo/image/upload/v1651544233/boi%E3%83%88%E3%83%AC/HowToMode_mq9isf.webp"
+      src="https://res.cloudinary.com/dzlhvpfmo/image/upload/v1652016264/boi%E3%83%88%E3%83%AC/77ccc5223a03a9fab6fc6ab60302a8b3_kobdtk.png"
       width="100%"
       height="65vh"
     />
@@ -20,7 +20,7 @@
     <p
       class="pb-5"
     >
-      現在3つの中から選べます。
+      現在4つの中から選べます。
     </p>
     <p
       class="pb-8"
@@ -35,7 +35,7 @@
     <v-img
       src="https://res.cloudinary.com/dzlhvpfmo/image/upload/v1651847193/boi%E3%83%88%E3%83%AC/8290d4739603c545808a957f722a595a_xqixvd.webp"
       width="100%"
-      height="65vh"
+      height="60vh"
     />
     <p
       class="pt-8 pb-5"
@@ -55,7 +55,7 @@
     <v-img
       src="https://res.cloudinary.com/dzlhvpfmo/image/upload/v1651847642/boi%E3%83%88%E3%83%AC/a0e0967ffcb302e8cce56974233d6ed4_biatha.webp"
       width="100%"
-      height="70vh"
+      height="65vh"
     />
     <p
       class="pt-8"
@@ -75,7 +75,7 @@
     <v-img
       src="https://res.cloudinary.com/dzlhvpfmo/image/upload/v1651847979/boi%E3%83%88%E3%83%AC/1dfd99d9ad8c985772cc7f4074289176_kgtv1g.jpg"
       width="100%"
-      height="80vh"
+      height="75vh"
     />
     <p
       class="pt-8"
@@ -98,7 +98,7 @@
     <v-img
       src="https://res.cloudinary.com/dzlhvpfmo/image/upload/v1651833567/boi%E3%83%88%E3%83%AC/791fe2b17ae9dca4894bccddf15e71b4_ayrewv.webp"
       width="100%"
-      height="90vh"
+      height="80vh"
     />
     <p
       class="py-7 font-weight-bold text-h5"

--- a/app/javascript/components/result/ThePracticeResult.vue
+++ b/app/javascript/components/result/ThePracticeResult.vue
@@ -93,7 +93,7 @@
               <v-icon
                 class="mr-2"
               >
-                mdi-twitter
+                {{ icons.twitter }}
               </v-icon>
               結果をツイートする！
             </v-btn>
@@ -114,7 +114,7 @@
               <v-icon
                 class="mr-2"
               >
-                mdi-content-save-outline
+                {{ icons.save }}
               </v-icon>
               結果を保存する
             </v-btn>
@@ -142,6 +142,8 @@
   </v-row>
 </template>
 <script>
+import { mdiTwitter } from '@mdi/js'
+import { mdiContentSaveOutline } from '@mdi/js'
 
 export default {
   name: 'ThePracticeResult',
@@ -163,6 +165,10 @@ export default {
       alert: null,
       normalForm: null,
       boinForm: null,
+      icons: { 
+        twitter: mdiTwitter,
+        save: mdiContentSaveOutline
+      } 
     }
   },
   computed: {

--- a/app/javascript/components/shared/TheHeader.vue
+++ b/app/javascript/components/shared/TheHeader.vue
@@ -43,7 +43,7 @@
           >
             <v-list-item>
               <v-list-item-icon>
-                <v-icon>mdi-home</v-icon>
+                <v-icon>{{ icons.home }}</v-icon>
               </v-list-item-icon>
               <v-list-item-title>HOME</v-list-item-title>
             </v-list-item>
@@ -55,7 +55,7 @@
           >
             <v-list-item>
               <v-list-item-icon>
-                <v-icon>mdi-account</v-icon>
+                <v-icon>{{ icons.account }}</v-icon>
               </v-list-item-icon>
               <v-list-item-title>MyPage</v-list-item-title>
             </v-list-item>
@@ -67,7 +67,7 @@
           >
             <v-list-item>
               <v-list-item-icon>
-                <v-icon>mdi-login</v-icon>
+                <v-icon>{{ icons.login }}</v-icon>
               </v-list-item-icon>
               <v-list-item-title>ログイン</v-list-item-title>
             </v-list-item>
@@ -79,7 +79,7 @@
           >
             <v-list-item>
               <v-list-item-icon>
-                <v-icon>mdi-file-sign</v-icon>
+                <v-icon>{{ icons.file }}</v-icon>
               </v-list-item-icon>
               <v-list-item-title>新規登録</v-list-item-title>
             </v-list-item>
@@ -92,7 +92,7 @@
           >
             <v-list-item>
               <v-list-item-icon>
-                <v-icon>mdi-logout</v-icon>
+                <v-icon>{{ icons.logout }}</v-icon>
               </v-list-item-icon>
               <v-list-item-title>ログアウト</v-list-item-title>
             </v-list-item>
@@ -103,7 +103,7 @@
           >
             <v-list-item>
               <v-list-item-icon>
-                <v-icon>mdi-lightbulb-on-outline</v-icon>
+                <v-icon>{{ icons.light }}</v-icon>
               </v-list-item-icon>
               <v-list-item-title>BOIトレとは？</v-list-item-title>
             </v-list-item>
@@ -116,7 +116,7 @@
               class="mt-9"
             >
               <v-list-item-icon>
-                <v-icon>mdi-note-text-outline</v-icon>
+                <v-icon>{{ icons.note }}</v-icon>
               </v-list-item-icon>
               <v-list-item-title>利用規約</v-list-item-title>
             </v-list-item>
@@ -127,7 +127,7 @@
           >
             <v-list-item>
               <v-list-item-icon>
-                <v-icon>mdi-shield-sun-outline</v-icon>
+                <v-icon>{{ icons.shield }}</v-icon>
               </v-list-item-icon>
               <v-list-item-title>プライバシーポリシー</v-list-item-title>
             </v-list-item>
@@ -138,7 +138,7 @@
           >
             <v-list-item>
               <v-list-item-icon>
-                <v-icon>mdi-help-circle-outline</v-icon>
+                <v-icon>{{ icons.help }}</v-icon>
               </v-list-item-icon>
               <v-list-item-title>お問い合わせ</v-list-item-title>
             </v-list-item>
@@ -150,7 +150,16 @@
 </template>
 
 <script>
-import TheFlashMessage from "components/shared/TheFlashMessage"
+const  TheFlashMessage  = () => import('components/shared/TheFlashMessage');
+import { mdiHome } from '@mdi/js';
+import { mdiAccount } from '@mdi/js';
+import { mdiLogin } from '@mdi/js';
+import { mdiLogout } from '@mdi/js';
+import { mdiLightbulbOnOutline } from '@mdi/js';
+import { mdiFileSign } from '@mdi/js';
+import { mdiNoteTextOutline } from '@mdi/js';
+import { mdiShieldSunOutline } from '@mdi/js';
+import { mdiHelpCircleOutline } from '@mdi/js';
 
 export default {
   name: "TheHeader",
@@ -161,6 +170,17 @@ export default {
     return {
       drawer: false,
       group: null,
+      icons: {
+        home: mdiHome,
+        account: mdiAccount,
+        login: mdiLogin,
+        logout: mdiLogout,
+        light: mdiLightbulbOnOutline,
+        file: mdiFileSign,
+        note: mdiNoteTextOutline,
+        shield: mdiShieldSunOutline,
+        help: mdiHelpCircleOutline
+      }
     }
   },
   computed: {

--- a/app/javascript/pages/how-to/index.vue
+++ b/app/javascript/pages/how-to/index.vue
@@ -78,7 +78,7 @@
             href="#tab-2"
             class="basil--text font-weight-bold text-h6 basil"
           >
-            新規登録後に利用可能な機能
+            新規登録後
           </v-tab>
           <v-tabs-slider color="basil--text" />
           <v-tab-item
@@ -112,8 +112,9 @@
 </template>
 
 <script>
-import TheHowToPlay from'../../components/how-to/TheHowToPlay'
-import TheAfterSignUp from'../../components/how-to/TheAfterSignUp'
+const TheHowToPlay = () => import('../../components/how-to/TheHowToPlay');
+const TheAfterSignUp = () => import('../../components/how-to/TheAfterSignUp');
+
 export default {
   name: "HowToIndex",
   components: {

--- a/app/javascript/pages/how-to/index.vue
+++ b/app/javascript/pages/how-to/index.vue
@@ -103,7 +103,7 @@
             color="error"
             @click="toTop"
           >
-            <v-icon>mdi-apple-keyboard-caps</v-icon>
+            <v-icon>{{ icons.apple }}</v-icon>
           </v-btn>
         </transition>
       </v-sheet>
@@ -114,7 +114,7 @@
 <script>
 const TheHowToPlay = () => import('../../components/how-to/TheHowToPlay');
 const TheAfterSignUp = () => import('../../components/how-to/TheAfterSignUp');
-
+import { mdiAppleKeyboardCaps } from '@mdi/js'
 export default {
   name: "HowToIndex",
   components: {
@@ -123,7 +123,8 @@ export default {
   },
   data() {
     return {
-      fab: false
+      fab: false,
+      icons: { apple: mdiAppleKeyboardCaps }
     }
   },
   methods: {

--- a/app/javascript/pages/login/login-form.vue
+++ b/app/javascript/pages/login/login-form.vue
@@ -23,7 +23,7 @@
         >
           <v-text-field 
             v-model="email"
-            prepend-icon="mdi-account-circle"
+            :prepend-icon= icons.account
             :error-messages="errors"
             label="メールアドレス"
             class="px-7"
@@ -38,7 +38,7 @@
           <v-text-field 
             v-model="password" 
             :type="showPassword ? 'text' : 'password'" 
-            prepend-icon="mdi-lock" 
+            :prepend-icon= icons.password 
             :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'" 
             label="パスワード"
             :error-messages="errors"
@@ -71,6 +71,8 @@
 </template>
 <script>
 const  TheMessage = () => import('../../components/shared/TheMessage');
+import { mdiAccountCircle } from '@mdi/js'
+import { mdiLock } from '@mdi/js'
 
 export default {
   name: "LoginForm",
@@ -83,7 +85,11 @@ export default {
       email: null,
       password: null,
       alert: null,
-      notice: null
+      notice: null,
+      icons: {
+        account: mdiAccountCircle,
+        password: mdiLock
+      }
     }
   },
   methods: {

--- a/app/javascript/pages/login/login-form.vue
+++ b/app/javascript/pages/login/login-form.vue
@@ -70,7 +70,7 @@
   </v-card>
 </template>
 <script>
-import TheMessage from '../../components/shared/TheMessage'
+const  TheMessage = () => import('../../components/shared/TheMessage');
 
 export default {
   name: "LoginForm",

--- a/app/javascript/pages/login/signup-form.vue
+++ b/app/javascript/pages/login/signup-form.vue
@@ -22,7 +22,7 @@
         >
           <v-text-field 
             v-model="name"
-            prepend-icon="mdi-account-circle"
+            :prepend-icon= icons.account
             label="ユーザー名"
             class="px-7" 
             :error-messages="errors"
@@ -36,7 +36,7 @@
         >
           <v-text-field 
             v-model="email"
-            prepend-icon="mdi-mail"
+            :prepend-icon= icons.email
             label="メールアドレス"
             class="px-7"
             :error-messages="errors"  
@@ -51,7 +51,7 @@
           <v-text-field 
             v-model="password" 
             :type="showPassword ? 'text' : 'password'" 
-            prepend-icon="mdi-lock" 
+            :prepend-icon= icons.password 
             :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'" 
             label="パスワード"
             class="px-7"
@@ -68,7 +68,7 @@
           <v-text-field 
             v-model="passwordConfirmation" 
             :type="showPassword ? 'text' : 'password'" 
-            prepend-icon="mdi-lock" 
+            :prepend-icon= icons.password 
             :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'" 
             label="パスワード確認" 
             class="px-7"
@@ -101,6 +101,9 @@
 </template>
 <script>
 const  TheMessage = () => import('../../components/shared/TheMessage');
+import { mdiAccountCircle } from '@mdi/js'
+import { mdiLock } from '@mdi/js'
+import { mdiEmail } from '@mdi/js'
 
 export default {
   name: "SignUpForm",
@@ -116,6 +119,11 @@ export default {
       passwordConfirmation: '',
       alert: null,
       notice: null,
+      icons: {
+        account: mdiAccountCircle,
+        password: mdiLock,
+        email: mdiEmail
+      }
     }
   },
   methods: {

--- a/app/javascript/pages/login/signup-form.vue
+++ b/app/javascript/pages/login/signup-form.vue
@@ -100,7 +100,7 @@
   </v-card>
 </template>
 <script>
-import TheMessage from '../../components/shared/TheMessage'
+const  TheMessage = () => import('../../components/shared/TheMessage');
 
 export default {
   name: "SignUpForm",

--- a/app/javascript/pages/my-page/index.vue
+++ b/app/javascript/pages/my-page/index.vue
@@ -53,8 +53,8 @@
 </template>
 
 <script>
-import TheCalendar from'../../components/calendar/TheCalendar'
-import TheResultTable from '../../components/calendar/TheResultTable'
+const  TheCalendar  = () => import('../../components/calendar/TheCalendar');
+const  TheResultTable  = () => import('../../components/calendar/TheResultTable');
 
 export default {
   name: 'MyPageIndex',

--- a/app/javascript/pages/my-page/index.vue
+++ b/app/javascript/pages/my-page/index.vue
@@ -26,7 +26,7 @@
             @click="triggerClick(item.action)"
           >
             <v-list-item-icon>
-              <v-icon v-text="item.icon" />
+              <v-icon>{{ item.icon }}</v-icon>
             </v-list-item-icon>
             <v-list-item-content>
               <v-list-item-title v-text="item.text" />
@@ -55,6 +55,8 @@
 <script>
 const  TheCalendar  = () => import('../../components/calendar/TheCalendar');
 const  TheResultTable  = () => import('../../components/calendar/TheResultTable');
+import { mdiCalendar } from '@mdi/js'
+import { mdiClock } from '@mdi/js'
 
 export default {
   name: 'MyPageIndex',
@@ -65,8 +67,8 @@ export default {
   data(){
     return {
       items: [ 
-        { text: 'カレンダー', icon: 'mdi-calendar', action: "OpenCalendar" },
-        { text: '練習履歴', icon: 'mdi-clock', action: "OpenHistory" }
+        { text: 'カレンダー', icon: mdiCalendar, action: "OpenCalendar" },
+        { text: '練習履歴', icon: mdiClock, action: "OpenHistory" }
       ],
       ChangeSheet: false
     }

--- a/app/javascript/pages/practice/boin-practice.vue
+++ b/app/javascript/pages/practice/boin-practice.vue
@@ -73,7 +73,9 @@
             class="red lighten-1"
             @click="startRecording"
           >
-            <v-icon>mdi-microphone</v-icon>
+            <v-icon
+            large
+            >{{ icons.microphone }}</v-icon>
           </v-btn>
         </v-row>
         <v-row
@@ -112,6 +114,7 @@
 </template>
 <script>
 const  ThePracticeResult  = () => import('components/result/ThePracticeResult.vue');
+import { mdiMicrophone } from '@mdi/js'
 
 export default {
   name: "BoinPractice",
@@ -130,7 +133,8 @@ export default {
       recordingText: '',
       boinRecognitionToHiragana: [],
       normalRecognition: null,
-      dialog: false
+      dialog: false,
+      icons: { microphone: mdiMicrophone }
     }
   },
   watch: {

--- a/app/javascript/pages/practice/boin-practice.vue
+++ b/app/javascript/pages/practice/boin-practice.vue
@@ -111,7 +111,7 @@
   </v-container>
 </template>
 <script>
-import ThePracticeResult from 'components/result/ThePracticeResult.vue'
+const  ThePracticeResult  = () => import('components/result/ThePracticeResult.vue');
 
 export default {
   name: "BoinPractice",

--- a/app/javascript/pages/practice/normal-practice.vue
+++ b/app/javascript/pages/practice/normal-practice.vue
@@ -53,7 +53,9 @@
             class="red lighten-1"
             @click="startRecording"
           >
-            <v-icon>mdi-microphone</v-icon>
+            <v-icon
+            large
+            >{{ icons.microphone }}</v-icon>
           </v-btn>
         </v-row> 
         <v-row
@@ -83,6 +85,7 @@
   </v-container>
 </template>
 <script>
+import { mdiMicrophone } from '@mdi/js';
 
 export default {
   name: "NormalPractice",
@@ -98,7 +101,8 @@ export default {
       normalRecognition: '',
       normalRecognitionToHiragana: [],
       recordingText: '',
-      normalForm: ''
+      normalForm: '',
+      icons: { microphone: mdiMicrophone }
     }
   },
   watch: {

--- a/app/javascript/pages/practice/normal-practice.vue
+++ b/app/javascript/pages/practice/normal-practice.vue
@@ -54,8 +54,10 @@
             @click="startRecording"
           >
             <v-icon
-            large
-            >{{ icons.microphone }}</v-icon>
+              large
+            >
+              {{ icons.microphone }}
+            </v-icon>
           </v-btn>
         </v-row> 
         <v-row

--- a/app/javascript/pages/top/index.vue
+++ b/app/javascript/pages/top/index.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script>
-import TheWarning from "components/shared/TheWarning"
+const  TheWarning  = () => import('components/shared/TheWarning');
 
 export default {
   name: "TopIndex",

--- a/app/javascript/plugins/vuetify.js
+++ b/app/javascript/plugins/vuetify.js
@@ -2,7 +2,6 @@ import Vue from 'vue'
 import Vuetify from 'vuetify'
 import 'vuetify/dist/vuetify.min.css'
 import minifyTheme from 'minify-css-string'
-import '@mdi/font/css/materialdesignicons.css'
 
 Vue.use(Vuetify)
 
@@ -15,6 +14,6 @@ export default new Vuetify({
     minifyTheme }
   },
   icons: {
-    iconfont: 'mdi',
+    iconfont: 'mdiSvg',
   }
 })

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "boitore",
   "private": true,
   "dependencies": {
-    "@mdi/font": "^6.5.95",
+    "@mdi/js": "^6.6.96",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,10 +910,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
-"@mdi/font@^6.5.95":
-  version "6.5.95"
-  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-6.5.95.tgz#203922f6dd46397de9eb1f5956b85339adb6344d"
-  integrity sha512-ES5rj6J39FUkHe/b3C9SJs8bqIungYhuU7rBINTBaHOv/Ce4RCb3Gw08CZVl32W33UEkgRkzyWaIedV4at+QHg==
+"@mdi/js@^6.6.96":
+  version "6.6.96"
+  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-6.6.96.tgz#119f79fa9327359421167a7d4b8bde26e84702ce"
+  integrity sha512-ke9PN5DjPCOlMfhioxeZYADz8Yiz6v47W0IYRza01SSJD7y1EwESVpwFnnFUso+eCoWtE1CO9cTIvQF6sEreuA==
 
 "@npmcli/fs@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
## 概要
現在mdiアイコンを一気に読み込んでいるためサイズが非常に大きい
必要なところにimportするように変更
単一コンポーネントを非同期化することによって、v-ifや表示されていないコンポーネントも読み込むことを
なくし、必要な時だけ読み込んでくれるように変更する

## 詳細
- mdi/jsを導入
- 各コンポーネントのmdiアイコンimportしたものに変更
- 単一コンポーネントを非同期化(headerは常に読み込んでおいてほしいのでimportにしておく)