### PR TITLE
fix: お問い合わせ, プライバシーポリシーでmdiアイコンを表示するように修正 

### DIFF
--- a/app/javascript/pages/shared/contact.vue
+++ b/app/javascript/pages/shared/contact.vue
@@ -28,7 +28,7 @@
             <v-icon
               class="mr-2"
             >
-              mdi-twitter
+              {{ icons.twitter }}
             </v-icon>
             @konjikicity
           </v-btn>
@@ -39,8 +39,15 @@
   </v-container>
 </template>
 <script>
+import { mdiTwitter } from '@mdi/js'
+
 export default {
-  name: "Contact"
+  name: "Contact",
+  data() {
+    return {
+      icons: { twitter: mdiTwitter }
+    }
+  }
 }
 </script>
 <style scoped>

--- a/app/javascript/pages/shared/privacy-policy.vue
+++ b/app/javascript/pages/shared/privacy-policy.vue
@@ -89,7 +89,7 @@
           <v-icon
             class="mr-2"
           >
-            mdi-twitter
+            {{ icons.twitter }}
           </v-icon>
           @konjikicity
         </v-btn>
@@ -108,8 +108,15 @@
   </v-container>
 </template>
 <script>
+import { mdiTwitter } from '@mdi/js'
+
 export default {
-  name: "PrivacyPolicy"
+  name: "PrivacyPolicy",
+  data() {
+    return {
+      icons:{ twitter: mdiTwitter}
+    }
+  }
 }
 </script>
 <style scoped>


### PR DESCRIPTION
## 概要
mdiアイコンがお問い合わせ, プライバシーポリシーで表示されていなかったので修正する

## 詳細
- お問い合わせ, プライバシーポリシーのtwitterアイコンを`mdi/js`で読み込む