### PR TITLE
refactor: 音声の削除処理をリファクタ, adminのmodeのindexアクションを修正

### DIFF
--- a/app/controllers/admins/modes_controller.rb
+++ b/app/controllers/admins/modes_controller.rb
@@ -2,7 +2,7 @@ class Admins::ModesController < Admins::ApplicationController
   before_action :set_mode, only: %i[edit update show destroy]
 
   def index
-    @modes = Mode.all.page(params[:page]).per(8).order(:id)
+    @modes = Mode.page(params[:page]).per(8).order(:id)
   end
 
   def new

--- a/app/controllers/api/v1/play_results_controller.rb
+++ b/app/controllers/api/v1/play_results_controller.rb
@@ -18,10 +18,12 @@ class Api::V1::PlayResultsController < Api::V1::ApplicationController
 
   def destroy
     play_results = PlayResult.find(params[:id])
-    play_results.remove_normal_voice!
-    play_results.remove_boin_voice!
-    play_results.save
-    play_results.destroy
+    if Rails.env.development?
+      play_results.delete
+    end
+    if Rails.env.production?
+      play_results.practice_delete
+    end
     render json: true
   end
 

--- a/app/controllers/api/v1/play_results_controller.rb
+++ b/app/controllers/api/v1/play_results_controller.rb
@@ -18,12 +18,8 @@ class Api::V1::PlayResultsController < Api::V1::ApplicationController
 
   def destroy
     play_results = PlayResult.find(params[:id])
-    if Rails.env.development?
-      play_results.delete
-    end
-    if Rails.env.production?
-      play_results.practice_delete
-    end
+    play_results.delete if Rails.env.development?
+    play_results.practice_delete if Rails.env.production?
     render json: true
   end
 

--- a/app/models/play_result.rb
+++ b/app/models/play_result.rb
@@ -36,8 +36,6 @@ class PlayResult < ApplicationRecord
   mount_uploader :boin_voice, AudioUploader
   mount_uploader :normal_voice, AudioUploader
   
-  private
-  
   def practice_delete
     remove_normal_voice!
     remove_boin_voice!

--- a/app/models/play_result.rb
+++ b/app/models/play_result.rb
@@ -35,7 +35,9 @@ class PlayResult < ApplicationRecord
 
   mount_uploader :boin_voice, AudioUploader
   mount_uploader :normal_voice, AudioUploader
-
+  
+  private
+  
   def practice_delete
     remove_normal_voice!
     remove_boin_voice!

--- a/app/models/play_result.rb
+++ b/app/models/play_result.rb
@@ -40,5 +40,6 @@ class PlayResult < ApplicationRecord
     remove_normal_voice!
     remove_boin_voice!
     save
+    delete
   end
 end

--- a/app/models/play_result.rb
+++ b/app/models/play_result.rb
@@ -35,4 +35,11 @@ class PlayResult < ApplicationRecord
 
   mount_uploader :boin_voice, AudioUploader
   mount_uploader :normal_voice, AudioUploader
+
+  def practice_delete
+    self.remove_normal_voice!
+    self.remove_boin_voice!
+    self.save
+  end
+
 end

--- a/app/models/play_result.rb
+++ b/app/models/play_result.rb
@@ -37,9 +37,8 @@ class PlayResult < ApplicationRecord
   mount_uploader :normal_voice, AudioUploader
 
   def practice_delete
-    self.remove_normal_voice!
-    self.remove_boin_voice!
-    self.save
+    remove_normal_voice!
+    remove_boin_voice!
+    save
   end
-
 end

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.3",
-    "admin-lte": "^3.0",
+    "admin-lte": "^3.2.0",
     "axios": "^0.25.0",
     "css-loader": "5",
     "dotenv": "^16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,7 +1293,7 @@ acorn@^7.0.0, acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-admin-lte@^3.0:
+admin-lte@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/admin-lte/-/admin-lte-3.2.0.tgz#9be383a6418c2323828466ab95af0eb083e4a597"
   integrity sha512-IDUfoU8jo9DVlB59lDEASAJXTesAEXDZ68DOHI3qg93r5ehVTkMl2x0ixgIyff8NiHeNYXpcOZh3tr6oGbvu9g==


### PR DESCRIPTION
## 概要
音声の削除機能のメソッドをモデルにまとめて、本番環境と開発環境で処理を分けた
adminのmodeのindexアクションのallが不必要だったので削除した。

## 詳細
- play_results_controllerを修正
- modeのindexアクションのallを削除