### PR TITLE
fix: csrf対策の記述を追加, dbのnameのユニーク制約をはず

### DIFF
--- a/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -1,7 +1,9 @@
 class Api::V1::Auth::OmniauthCallbacksController < DeviseTokenAuth::OmniauthCallbacksController
+  protect_from_forgery
+  
   def omniauth_success
     super
-    @resource.update(nickname: @resource.name)
+    @resource.update(nickname: @resource.name) if @resource.nickname.nil?
   end
 
   protected

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  protect_from_forgery
+  
   private
 
   def sign_up_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  skip_before_action :verify_authenticity_token
+  protect_from_forgery
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,6 @@
 #
 # Indexes
 #
-#  index_users_on_name              (name) UNIQUE
 #  index_users_on_uid_and_provider  (uid,provider) UNIQUE
 #
 class User < ApplicationRecord

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,5 @@ module VowelTraining
                        fixtures: true
       g.fixture_replacement :factory_bot, dir: 'spec/factories'
     end
-    config.action_controller.allow_forgery_protection = false
   end
 end

--- a/db/migrate/20220617105436_remove_user_to_name_index.rb
+++ b/db/migrate/20220617105436_remove_user_to_name_index.rb
@@ -1,0 +1,5 @@
+class RemoveUserToNameIndex < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :users, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_17_004846) do
+ActiveRecord::Schema.define(version: 2022_06_17_105436) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,7 +68,6 @@ ActiveRecord::Schema.define(version: 2022_06_17_004846) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "nickname", limit: 50
     t.string "image"
-    t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,7 +16,6 @@
 #
 # Indexes
 #
-#  index_users_on_name              (name) UNIQUE
 #  index_users_on_uid_and_provider  (uid,provider) UNIQUE
 #
 FactoryBot.define do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,7 +16,6 @@
 #
 # Indexes
 #
-#  index_users_on_name              (name) UNIQUE
 #  index_users_on_uid_and_provider  (uid,provider) UNIQUE
 #
 require 'rails_helper'


### PR DESCRIPTION
## 概要
自分の環境では何の問題も出なかったが他の方から`the change you wanted was rejected`
 という表示がでたとのことなのでCSRFについて修正

## 詳細
- omniauthの処理をしているomniauth_controllerにCSRF対策の記述
- ついでにnameカラムにunique制約は別になくてもいいと思ったのではずす

現在他のユーザーを一覧で見れるような機能は考えていないため