### PR TITLE
refactor: DB制約を変更したことによるテストコードを修正, loginができていなかった部分を修正

### DIFF
--- a/app/javascript/pages/login/login-form.vue
+++ b/app/javascript/pages/login/login-form.vue
@@ -12,6 +12,7 @@
         <v-card
           class="mx-auto"
           height="500px"
+          id="login"
         >
           <v-card-title>
             <h2 class="font-weight-bold pt-5 pl-2">
@@ -195,13 +196,12 @@ export default {
   methods: {
     async login(){
       try {
-        await this.$axios.post('auth/sign_in', {
+        const res = await this.$axios.post('auth/sign_in', {
           email: this.email,
           password: this.password,
-        }
-        )
+        })
         this.$store.commit('login/loginUser', { token: res.headers["access-token"], client: res.headers.client,
-          uid: res.data.data.uid, name: res.data.data.name,id: res.data.data.id
+          uid: res.data.data.uid, name: res.data.data.name, id: res.data.data.id
         })
         this.$router.push({ name: 'ModeIndex' })
         this.$store.dispatch(

--- a/app/javascript/pages/login/login-form.vue
+++ b/app/javascript/pages/login/login-form.vue
@@ -10,9 +10,9 @@
         cols="5"
       >
         <v-card
+          id="login"
           class="mx-auto"
           height="500px"
-          id="login"
         >
           <v-card-title>
             <h2 class="font-weight-bold pt-5 pl-2">

--- a/app/javascript/pages/login/signup-form.vue
+++ b/app/javascript/pages/login/signup-form.vue
@@ -27,7 +27,7 @@
             >
               <validation-provider
                 v-slot="{ errors }"
-                rules="required|max:10"
+                rules="required|max:50"
                 name="ユーザー名"
               >
                 <v-text-field 
@@ -231,8 +231,7 @@ export default {
           email: this.email,
           password: this.password,
           password_confirmation: this.passwordConfirmation
-        }
-        )
+        })
         this.$store.commit('login/loginUser', { token: res.headers["access-token"], client: res.headers.client, 
           uid: res.data.data.uid, name: res.data.data.name,id: res.data.data.id
         })
@@ -249,6 +248,7 @@ export default {
       catch (error) {
         this.alert = '名前またはメールアドレスが使用されています。'
         this.notice = null
+        console.log({ error })
       }
     }
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :omniauthable
   validates :name, presence: true, length: { maximum: 50 }
+  validates :nickname, length: { maximum: 50 }
   validates :email, presence: true
   include DeviseTokenAuth::Concerns::User
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,6 +21,7 @@
 FactoryBot.define do
   factory :user do
     name { Faker::Name.name }
+    nickname { Faker::Name.name }
     sequence(:email) { |n| "#{n}_" + Faker::Internet.email }
     password { 'password' }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -60,4 +60,24 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "文字制限のバリデーション確認" do
+    context "名前が50文字以上だった場合" do
+      let(:user) { build(:user, name: Faker::Lorem.characters(number:51) )}
+
+      it "エラーになる" do
+        user.valid?
+        expect(user.errors.messages[:name]).to include "は50文字以内で入力してください"
+      end
+    end
+
+    context "nicknameが50文字以上だった場合" do
+      let(:user) { build(:user, nickname: Faker::Lorem.characters(number:51) )}
+      
+      it "エラーになる" do
+        user.valid?
+        expect(user.errors.messages[:nickname]).to include "は50文字以内で入力してください"
+      end
+    end
+  end
 end

--- a/spec/system/admin_user_spec.rb
+++ b/spec/system/admin_user_spec.rb
@@ -41,49 +41,20 @@ RSpec.describe "AdminのUserCRUD", type: :system do
       end
 
       describe '文字制限の確認' do
-        context '名前を10文字以上で作成した場合' do
+        context '名前を50文字以上で作成した場合' do
           it 'エラーメッセージが表示される' do
             visit new_admins_user_path
-            fill_in('名前', with: Faker::Lorem.characters(number:11) )
+            fill_in('名前', with: Faker::Lorem.characters(number:51) )
             fill_in('メールアドレス', with: 'example@example.com')
             fill_in('パスワード', with: 'password')
             fill_in('パスワード確認', with: 'password')
             click_on('登録する')
             expect(page).to have_content('ユーザーを作成できませんでした')
-            expect(page).to have_content('名前は10文字以内で入力してください')
+            expect(page).to have_content('名前は50文字以内で入力してください')
         end
       end
     end
 
-      describe '重複の確認' do
-        context '作成済みの名前で作成した場合' do
-          let(:user) { create(:user) }
-          it 'エラーメッセージが表示される' do
-            visit new_admins_user_path
-            fill_in('名前', with: user.name )
-            fill_in('メールアドレス', with: 'example@example.com')
-            fill_in('パスワード', with: 'password')
-            fill_in('パスワード確認', with: 'password')
-            click_on('登録する')
-            expect(page).to have_content('ユーザーを作成できませんでした')
-            expect(page).to have_content('名前はすでに存在します')
-          end
-        end
-
-        context '作成済みのメールアドレスで作成した場合' do
-          let(:user) { create(:user) }
-          it 'エラーメッセージが表示される' do
-            visit new_admins_user_path
-            fill_in('名前', with: 'sonoda' )
-            fill_in('メールアドレス', with: user.email )
-            fill_in('パスワード', with: 'password')
-            fill_in('パスワード確認', with: 'password')
-            click_on('登録する')
-            expect(page).to have_content('ユーザーを作成できませんでした')
-            expect(page).to have_content('メールアドレスはすでに存在します')
-          end
-        end
-      end
       describe 'フォーマットの検証' do
         context 'フォーマットが正しくないメールアドレスを作成した場合' do
           invalid_addresses = %w[user@example,com USER.foo.COM A_US-ER@foo. foo@bar_foo.jp foo@bar+baz.com foo@bar..com foo\ bar@baz.com]
@@ -136,41 +107,15 @@ RSpec.describe "AdminのUserCRUD", type: :system do
       end
 
       describe '文字制限の確認' do
-        context '名前を10文字以上で作成した場合' do
+        context '名前を50文字以上で作成した場合' do
           let(:user) { create(:user) }
           it 'エラーメッセージが表示される' do
             visit edit_admins_user_path(user)
-            fill_in('名前', with: Faker::Lorem.characters(number:11) )
+            fill_in('名前', with: Faker::Lorem.characters(number:51) )
             fill_in('メールアドレス', with: 'example@example.com')
             click_on('更新する')
             expect(page).to have_content('ユーザーを更新できませんでした')
-            expect(page).to have_content('名前は10文字以内で入力してください')
-          end
-        end
-      end
-
-      describe '重複の確認' do
-        context '作成済みの名前で作成した場合' do
-          let(:user1) { create(:user) }
-          let(:user2) { create(:user) }
-          it 'エラーメッセージが表示される' do
-            visit edit_admins_user_path(user2)
-            fill_in('名前', with: user1.name )
-            click_on('更新する')
-            expect(page).to have_content('ユーザーを更新できませんでした')
-            expect(page).to have_content('名前はすでに存在します')
-          end
-        end
-
-        context '作成済みのメールアドレスで作成した場合' do
-          let(:user1) { create(:user) }
-          let(:user2) { create(:user) }
-          it 'エラーメッセージが表示される' do
-            visit edit_admins_user_path(user2)
-            fill_in('メールアドレス', with: user1.email )
-            click_on('更新する')
-            expect(page).to have_content('ユーザーを更新できませんでした')
-            expect(page).to have_content('メールアドレスはすでに存在します')
+            expect(page).to have_content('名前は50文字以内で入力してください')
           end
         end
       end

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe "ユーザーログイン", type: :system, js:true do
         fill_in('メールアドレス', with: user.email)
         fill_in('パスワード', with: 'password')
         send_keys :return
-        click_on('ログイン')
+        within "#login" do
+          click_on('ログイン')
+        end
         expect(page).to have_content('モード選択')
         expect(page).to have_content('ログインしました')
       end
@@ -38,7 +40,9 @@ RSpec.describe "ユーザーログイン", type: :system, js:true do
           fill_in('メールアドレス', with: Faker::Internet.email )
           fill_in('パスワード', with: Faker::Internet.password(min_length:8) )
           send_keys :return
-          click_on('ログイン')
+          within "#login" do
+            click_on('ログイン')
+          end
           expect(page).to have_content('メールアドレスまたはパスワードが違います')
         end
       end

--- a/spec/system/sign_up_spec.rb
+++ b/spec/system/sign_up_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "ユーザー登録", type: :system, js:true do
               fill_in('メールアドレス', with: '')
               fill_in('パスワード', with: '')
               fill_in('パスワード確認', with: '')
-              find('input[id="input-54"]').click
+              find('input[id="input-52"]').click
               expect(page).to have_content('ユーザー名を入力してください')
               expect(page).to have_content('メールアドレスを入力してください')
               expect(page).to have_content('パスワードを入力してください')
@@ -34,46 +34,12 @@ RSpec.describe "ユーザー登録", type: :system, js:true do
           end
       end
 
-      describe '一意性の検証' do
-        context '使用されているメールアドレスを使用した場合' do
-          let(:user) { create(:user) }
-          
-          it 'エラーメッセージ「名前またはメールアドレスが使用されています」が表示される' do
-            sign_up(user)
-            visit('/sign-up')
-            fill_in('ユーザー名', with: Faker::Name.name )
-            fill_in('メールアドレス', with: user.email )
-            fill_in('パスワード', with: 'password')
-            fill_in('パスワード確認', with: 'password')
-            send_keys :return
-            click_on('登録')
-            expect(page).to have_content('名前またはメールアドレスが使用されています')
-          end
-        end
-
-        context '使用されている名前を使用した場合' do
-          let(:user) { create(:user) }
-          
-          it 'エラーメッセージ「名前またはメールアドレスが使用されています」が表示される' do
-            sign_up(user)
-            visit('/sign-up')
-            fill_in('ユーザー名', with: user.name)
-            fill_in('メールアドレス', with: 'test@expample.com')
-            fill_in('パスワード', with: 'password')
-            fill_in('パスワード確認', with: 'password')
-            send_keys :return
-            click_on('登録')
-            expect(page).to have_content('名前またはメールアドレスが使用されています')
-          end
-      end
-    end
-
     describe '文字数の検証' do
-      context '10文字以上の名前を入力した場合' do
-        it 'エラーメッセージ「10文字以内で入力してください」が表示される' do
-          fill_in('ユーザー名', with: Faker::Lorem.characters(number: 11))
-          find('input[id="input-54"]').click
-          expect(page).to have_content('10文字以内で入力してください')
+      context '50文字以上の名前を入力した場合' do
+        it 'エラーメッセージ「50文字以内で入力してください」が表示される' do
+          fill_in('ユーザー名', with: Faker::Lorem.characters(number: 51))
+          find('input[id="input-58"]').click
+          expect(page).to have_content('50文字以内で入力してください')
         end
       end
     end
@@ -83,7 +49,7 @@ RSpec.describe "ユーザー登録", type: :system, js:true do
       it 'エラーメッセージ「メールアドレスの形式が正しくありません」が表示される' do
         invalid_addresses.each do |invalid_address|
           fill_in('メールアドレス', with: invalid_address)
-          find('input[id="input-54"]').click
+          find('input[id="input-58"]').click
           expect(page).to have_content('メールアドレスの形式が正しくありません')
         end
       end


### PR DESCRIPTION
## 概要
SNS認証にて同じメールアドレスで複数のSNSを登録していることを考慮して
unique制約をはずした。
それによるテストコードが通らなくなっていたので修正
テストを実行して登録しているメールアドレスでloginができないバグを発見したので修正

## 詳細
- modelスペックを修正
- systemスペックを修正
- loginができていなかった部分を修正